### PR TITLE
Fixed typos in pom.xml for phase1 and final.

### DIFF
--- a/final/pom.xml
+++ b/final/pom.xml
@@ -122,7 +122,7 @@
                     <!-- Comment in the below snippet to bind to all IPs instead of just localhost -->
                     <!-- address>0.0.0.0</address>
                     <port>8080</port -->
-                    <!-- Comment in the below snippet to enable local debugging with a remove debugger
+                    <!-- Comment in the below snippet to enable local debugging with a remote debugger
                          like those included with Eclipse or IntelliJ -->
                     <!-- jvmFlags>
                       <jvmFlag>-agentlib:jdwp=transport=dt_socket,address=8000,server=y,suspend=n</jvmFlag>

--- a/phase1/pom.xml
+++ b/phase1/pom.xml
@@ -105,7 +105,7 @@
                     <!-- Comment in the below snippet to bind to all IPs instead of just localhost -->
                     <!-- address>0.0.0.0</address>
                     <port>8080</port -->
-                    <!-- Comment in the below snippet to enable local debugging with a remove debugger
+                    <!-- Comment in the below snippet to enable local debugging with a remote debugger
                          like those included with Eclipse or IntelliJ -->
                     <!-- jvmFlags>
                       <jvmFlag>-agentlib:jdwp=transport=dt_socket,address=8000,server=y,suspend=n</jvmFlag>


### PR DESCRIPTION
Fixed typo: "remove debugger" to "remote debugger" for both pom.xml files.  